### PR TITLE
Limit walk() to document.body

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -69,7 +69,7 @@ function handleText(textNode) {
 function walkTheDoc(doc) {
   const documentTitle = doc.getElementsByTagName('title')[0]; 
 
-  walk(doc);
+  walk(doc.body);
   documentTitle = handleText(documentTitle);
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Birds Aren't Real",
-  "version": "1.1",
+  "version": "1.2",
   "description": "Corrects the word 'bird' to 'government drone'.",
   "author": "Anna Sobolewska",
   "content_scripts":


### PR DESCRIPTION
Running the `walk` function on the entire `document` can cause issues with replacements in the document head (which is Not Good™).

This limits `walk()` to operating only on the document body.

May this glorious extension continue to spread its message of truth!